### PR TITLE
feat: make macos builds universal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       
       - run: npm run prebuild
       - if: matrix.os == 'macos-latest'
-        run: npm run prebuild -- --arch arm64
+        run: cp prebuilds/@iarahealth/node-hid-v2.2.1-napi-v3-darwin-x64.tar.gz prebuilds/@iarahealth/node-hid-v2.2.1-napi-v3-darwin-arm64.tar.gz
 
       - run: npm run prebuild-upload ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       
       - run: npm run prebuild
       - if: matrix.os == 'macos-latest'
-        run: cp prebuilds/@iarahealth/node-hid-v2.2.1-napi-v3-darwin-x64.tar.gz prebuilds/@iarahealth/node-hid-v2.2.1-napi-v3-darwin-arm64.tar.gz
+        run: cp prebuilds/@iarahealth/node-hid-v2.2.2-napi-v3-darwin-x64.tar.gz prebuilds/@iarahealth/node-hid-v2.2.2-napi-v3-darwin-arm64.tar.gz
 
       - run: npm run prebuild-upload ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Publish
 
 on:
@@ -12,7 +9,6 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019]
-        node-version: [10.x, 12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -27,10 +23,9 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16
           registry-url: "https://npm.pkg.github.com"
 
       - run: npm run prepublishOnly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,11 @@ jobs:
       - run: npm run prepublishOnly
       - run: npm install --build-from-source
       - run: npm test
+      
       - run: npm run prebuild
+      - if: matrix.os == 'macos-latest'
+        run: npm run prebuild -- --arch arm64
+
       - run: npm run prebuild-upload ${{ secrets.GITHUB_TOKEN }}
 
   publish:

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,7 +23,10 @@
                         'CLANG_CXX_LIBRARY': 'libc++',
                         'MACOSX_DEPLOYMENT_TARGET': '10.9',
                         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                        'OTHER_CFLAGS': [ '-arch x86_64', '-arch arm64'],
                         'OTHER_LDFLAGS': [
+                            '-arch x86_64', 
+                            '-arch arm64',
                             '-framework IOKit',
                             '-framework CoreFoundation',
                             '-framework AppKit'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iarahealth/node-hid",
   "description": "USB HID device access library",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Hans Hübner <hans.huebner@gmail.com> (https://github.com/hanshuebner)",
   "bugs": "https://github.com/iarahealth/node-hid/issues",
   "homepage": "https://github.com/iarahealth/node-hid#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iarahealth/node-hid",
   "description": "USB HID device access library",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Hans Hübner <hans.huebner@gmail.com> (https://github.com/hanshuebner)",
   "bugs": "https://github.com/iarahealth/node-hid/issues",
   "homepage": "https://github.com/iarahealth/node-hid#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iarahealth/node-hid",
   "description": "USB HID device access library",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "author": "Hans Hübner <hans.huebner@gmail.com> (https://github.com/hanshuebner)",
   "bugs": "https://github.com/iarahealth/node-hid/issues",
   "homepage": "https://github.com/iarahealth/node-hid#readme",


### PR DESCRIPTION
This PR makes the underlying HID.node file generated by the node-gyp build on macOS systems universal.